### PR TITLE
Remove `postinstall` npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "test": "jest --verbose",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "postinstall": "npm run build",
     "prepublish": "npm run lint && npm run test && npm run build"
   },
   "repository": {


### PR DESCRIPTION
Seeing some funny behaviour with `postinstall` where it is run before dependencies are installed. :-|

Removing the script altogether as compiled lib is in npm package already via `prepublish`.