### PR TITLE
v2: update redux-saga

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Kasia Changelog
+
+- __v2.0.0__ - _04/08/16_
+
+    - [BREAKING] Updated sagas export to accommodate changes to redux-saga API introduced in [v0.10.0]().
+    - Updates to README: fixed bad `node-wpapi` examples with endpoint missing `/wp-json`
+    suffix, added quick Spongebob example as intro. :ok_hand:
+    - Added `CHANGELOG.md`.
+
+---
+
+- __v1.0.2__ - _04/08/16_
+
+    - Removed `postinstall` npm script because it runs before dependencies are installed(?!).
+
+- __v1.0.1__ - _04/08/16_
+
+    - Fix bad import statements (see next bullet).
+    - Rename `ContentTypes.js` -> `contentTypes.js` as this was causing an error on
+    Unix systems as import statements used the latter filename.
+
+- __v1.0.0__ - _03/08/16_
+
+    - Release! :tophat:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kasia",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "A React Redux toolset for the WordPress API",
   "main": "lib/index.js",
   "jsnext:main": "src/index.js",
@@ -45,7 +45,7 @@
     "react-dom": "^15.0.1",
     "react-redux": "^4.4.5",
     "redux": "^3.4.0",
-    "redux-saga": "^0.9.5",
+    "redux-saga": "^0.11.0",
     "wp-api-response-modify": "^2.0.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,11 @@
 import merge from 'lodash.merge'
 import { camelize } from 'humps'
+import * as effects from 'redux-saga/effects'
 
 import invariants from './invariants'
 import makeReducer from './reducer'
 import { setWP } from './wpapi'
-import { fetchSaga } from './sagas'
+import { watchRequests } from './sagas'
 import { registerContentType } from './contentTypes'
 
 /**
@@ -12,7 +13,7 @@ import { registerContentType } from './contentTypes'
  * @type {Object}
  */
 const componentsBase = {
-  sagas: [fetchSaga],
+  sagas: [watchRequests],
   reducers: {}
 }
 
@@ -51,7 +52,7 @@ export default function Kasia (opts = {}) {
 
     return {
       sagas: plugins.sagas.concat(plugin.sagas),
-      reducers: merge(plugins.reducers, plugin.reducers)
+      reducers: merge({}, plugins.reducers, plugin.reducers)
     }
   }, componentsBase)
 
@@ -64,6 +65,6 @@ export default function Kasia (opts = {}) {
 
   return {
     kasiaReducer: makeReducer({ keyEntitiesBy }, plugins),
-    kasiaSagas: plugins.sagas
+    kasiaSagas: plugins.sagas.map((saga) => effects.spawn(saga))
   }
 }

--- a/src/sagas.js
+++ b/src/sagas.js
@@ -1,5 +1,4 @@
-import { takeEvery } from 'redux-saga'
-import { call, put } from 'redux-saga/effects'
+import * as effects from 'redux-saga/effects'
 import { camelize } from 'humps'
 
 import { WP } from './wpapi'
@@ -84,13 +83,16 @@ export function * fetch (action) {
   const { id } = action
 
   try {
-    const result = yield call(resolveQueryFn(action), WP)
-    yield put(completeRequest(id, result))
+    const result = yield effects.call(resolveQueryFn(action), WP)
+    yield effects.put(completeRequest(id, result))
   } catch (err) {
-    yield put(failRequest(id, err))
+    yield effects.put(failRequest(id, err))
   }
 }
 
-export function * fetchSaga () {
-  yield * takeEvery(Request.Create, fetch)
+export function * watchRequests () {
+  while (true) {
+    const action = yield effects.take(Request.Create)
+    yield effects.fork(fetch, action)
+  }
 }

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -3,8 +3,9 @@
 
 jest.disableAutomock()
 
-import { combineReducers, createStore } from 'redux'
 import WP from 'wpapi'
+import { combineReducers, createStore } from 'redux'
+import * as effects from 'redux-saga/effects'
 
 import Kasia from '../src'
 
@@ -14,23 +15,23 @@ let didHitPluginReducer = false
 
 function pluginSaga () {}
 
-const pluginReducer = {
-  [testActionType]: (action, state) => {
-    didHitPluginReducer = true
-    return state
-  }
-}
-
-const plugin = () => {
-  return {
-    reducers: pluginReducer,
-    sagas: [pluginSaga]
-  }
-}
-
 function setup () {
+  const pluginReducer = {
+    [testActionType]: (action, state) => {
+      didHitPluginReducer = true
+      return state
+    }
+  }
+
+  const plugin = () => {
+    return {
+      reducers: pluginReducer,
+      sagas: [pluginSaga]
+    }
+  }
+
   const { kasiaReducer, kasiaSagas } = Kasia({
-    WP: new WP({ endpoint: 'http://localhost' }),
+    WP: new WP({ endpoint: 'wow-so-much-endpoint' }),
     plugins: [plugin]
   })
 
@@ -49,6 +50,6 @@ describe('Plugin', () => {
   })
 
   it('should add the plugin saga to sagas array', () => {
-    expect(kasiaSagas.indexOf(pluginSaga)).toEqual(1)
+    expect(kasiaSagas).toContain(effects.spawn(pluginSaga))
   })
 })

--- a/test/sagas/sagas.js
+++ b/test/sagas/sagas.js
@@ -13,7 +13,7 @@ jest.unmock('../../src/wpapi')
 jest.unmock('../../src/index')
 jest.unmock('../../src/sagas')
 
-import { put, call } from 'redux-saga/effects'
+import * as effects from 'redux-saga/effects'
 
 import { setWP } from '../../src/wpapi'
 import { fetch } from '../../src/sagas'
@@ -54,7 +54,7 @@ describe('Sagas', () => {
 
     it('yields a put with completeRequest action', () => {
       expect(generator.next().value)
-        .toEqual(put(completeRequest(queryId, undefined)))
+        .toEqual(effects.put(completeRequest(queryId, undefined)))
     })
   })
 
@@ -64,12 +64,12 @@ describe('Sagas', () => {
     const generator = fetch(action)
 
     it('yields a call to correctly resolved queryFn', () => {
-      expect(generator.next().value).toEqual(call(queryFn, WP))
+      expect(generator.next().value).toEqual(effects.call(queryFn, WP))
     })
 
     it('puts a completeRequest action with result', () => {
       expect(generator.next(mockResult).value)
-        .toEqual(put(completeRequest(queryId, mockResult)))
+        .toEqual(effects.put(completeRequest(queryId, mockResult)))
     })
   })
 })


### PR DESCRIPTION
- [BREAKING] Updated sagas export to accommodate changes to redux-saga API introduced in [v0.10.0]().
- Updates to README: fixed bad `node-wpapi` examples with endpoint missing `/wp-json` suffix, added quick Spongebob example as intro. :ok_hand:
- Added `CHANGELOG.md`.