### PR TITLE
Fix connectWpQuery fn not receiving props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kasia",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A React Redux toolset for the WordPress API",
   "main": "lib/index.js",
   "jsnext:main": "src/index.js",

--- a/src/connect/connectWpQuery.js
+++ b/src/connect/connectWpQuery.js
@@ -116,7 +116,7 @@ export default function connectWpQuery (queryFn) {
 
       componentWillMount () {
         this.queryId = queryIds.length ? queryIds.pop() : idGen()
-        this.dispatch()
+        this.dispatch(this.props)
       }
 
       componentWillReceiveProps (_nextProps) {
@@ -131,7 +131,7 @@ export default function connectWpQuery (queryFn) {
         // Make a request for new data if the current props and next props are different
         if (!isEqual(nextProps, thisProps)) {
           this.queryId = queryIds.length ? queryIds.pop() : idGen()
-          this.dispatch()
+          this.dispatch(nextProps)
         }
       }
     }


### PR DESCRIPTION
Fixes bug where `connectWpQuery` wasn't receiving the component's props.