### PR TITLE
Release v2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+
+node_js:
+  - "4"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Kasia Changelog
 
+- __v2.2.0__ - _08/08/16_
+
+    - Added missing dependencies in `package.json`.
+    - Removed unnecessary unmock of `lodash` in tests.
+    - Fix query IDs being picked in reverse order when server-side rendering.
+    - Added `.travis.yml`.
+
+- __v2.1.0__ - _05/08/16_
+
+    - Fix `connectWpQuery` fn not receiving props.
+
 - __v2.0.0__ - _04/08/16_
 
     - [BREAKING] Updated sagas export to accommodate changes to redux-saga API introduced in [v0.10.0]().

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "react-redux": "^4.4.5",
     "redux": "^3.4.0",
     "redux-saga": "^0.11.0",
-    "wp-api-response-modify": "^2.0.0"
+    "wp-api-response-modify": "^2.0.0",
+    "wpapi": "^0.9.1"
   },
   "devDependencies": {
     "babel-cli": "6.6.5",
@@ -63,6 +64,7 @@
     "jest": "^0.1.40",
     "jest-cli": "^11.0.2",
     "lodash.values": "^4.1.0",
+    "react-addons-test-utils": "^15.3.0",
     "rimraf": "^2.5.2",
     "snazzy": "^4.0.0",
     "standard": "^7.1.2"

--- a/src/connect/connectWpPost.js
+++ b/src/connect/connectWpPost.js
@@ -122,7 +122,7 @@ export default function connectWpPost (contentType, id) {
       }
 
       componentWillMount () {
-        this.queryId = queryIds.length ? queryIds.pop() : idGen()
+        this.queryId = queryIds.length ? queryIds.shift() : idGen()
         this.dispatch(this.props)
       }
 
@@ -135,7 +135,7 @@ export default function connectWpPost (contentType, id) {
         //  - the identifier has changed
         //  - an entity cannot be derived from the store using `nextProps`
         if (shouldDispatch && !nextBuiltProps.kasia[name]) {
-          this.queryId = queryIds.length ? queryIds.pop() : idGen()
+          this.queryId = queryIds.length ? queryIds.shift() : idGen()
           this.dispatch(nextProps)
         }
       }

--- a/src/connect/connectWpQuery.js
+++ b/src/connect/connectWpQuery.js
@@ -115,7 +115,7 @@ export default function connectWpQuery (queryFn) {
       }
 
       componentWillMount () {
-        this.queryId = queryIds.length ? queryIds.pop() : idGen()
+        this.queryId = queryIds.length ? queryIds.shift() : idGen()
         this.dispatch(this.props)
       }
 
@@ -130,7 +130,7 @@ export default function connectWpQuery (queryFn) {
 
         // Make a request for new data if the current props and next props are different
         if (!isEqual(nextProps, thisProps)) {
-          this.queryId = queryIds.length ? queryIds.pop() : idGen()
+          this.queryId = queryIds.length ? queryIds.shift() : idGen()
           this.dispatch(nextProps)
         }
       }

--- a/test/sagas/sagas.js
+++ b/test/sagas/sagas.js
@@ -1,7 +1,6 @@
 /* eslint-env jasmine */
 /* global jest:false */
 
-jest.unmock('lodash')
 jest.unmock('normalizr')
 jest.unmock('redux-saga')
 jest.unmock('redux-saga/effects')


### PR DESCRIPTION
Release `v2.2.0`

- Added missing dependencies in `package.json`.
- Removed unnecessary unmock of `lodash` in tests.
- Fix query IDs being picked in reverse order when server-side rendering.
- Added `.travis.yml`.