### PR TITLE
v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Kasia Changelog
 
+- __v2.3.0__ - _10/08/16_
+
+    - Fix functions passed as props to `connectWpQuery` causing infinite dispatching.
+    ([#16](https://github.com/outlandishideas/kasia/issues/16))
+    - Added second parameter `propsComparatorFn` to `connectWpQuery`.
+    - Fix `connectWpPost` derived query chaining failing due to dependency on object property order.
+    - Updates to README: added docs for new functionality, fix typos
+    ([#19](https://github.com/outlandishideas/kasia/pull/19)).
+
 - __v2.2.0__ - _08/08/16_
 
     - Added missing dependencies in `package.json`.

--- a/README.md
+++ b/README.md
@@ -170,9 +170,13 @@ export default connectWpPost(Page, (props) => props.params.slug)(Post)
 
 Connect a component to the result of an arbitrary WP-API query.
 
-- __queryFn__ {Function} A function that accepts args `wpapi` and `props` and should return a WP-API query
+- __queryFn__ {Function} Function that accepts args `wpapi` and `props` and should return a WP-API query
+- __propsComparatorFn__ {Function} Function that determines if new data should be requested by inspecting props
 
 Returns a connected component.
+
+By default the component will request new data via the given `queryFn` if the `propsComparatorFn` returns true.
+The default property comparison is performed only on primitive values on the props objects.
 
 Entities returned from the query will be placed on `this.props.kasia.entities` under the same
 normalised structure as described in [The Shape of Things](#the-shape-of-things).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kasia",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "A React Redux toolset for the WordPress API",
   "main": "lib/index.js",
   "jsnext:main": "src/index.js",
@@ -37,7 +37,7 @@
     "humps": "^1.0.0",
     "invariant": "^2.2.1",
     "lodash.find": "^4.3.0",
-    "lodash.isequal": "^4.2.0",
+    "lodash.isequalwith": "^4.3.1",
     "lodash.merge": "^4.3.5",
     "normalizr": "^2.0.1",
     "pick-to-array": "^1.0.0",

--- a/src/connect/connectWpPost.js
+++ b/src/connect/connectWpPost.js
@@ -9,6 +9,12 @@ import { getContentType } from '../contentTypes'
 import { makeWpPostPreloaderFn } from './preloaders'
 
 /**
+ * IDs of queries created through the preloader.
+ * @type {Array<Number>}
+ */
+const queryIds = []
+
+/**
  * Find an entity in `entities` with the given `identifier`.
  * @param {Object} entities Entity collection
  * @param {String|Number} identifier Entity ID or slug
@@ -53,11 +59,9 @@ function findEntity (entities, identifier) {
  *
  * @params {String} contentType The content type of the data to fetch from WP-API
  * @params {Function|String|Number} id The entity's ID or slug or a function that derives either from props
- * @returns {Function}
+ * @returns {Function} Decorated component
  */
 export default function connectWpPost (contentType, id) {
-  const queryIds = []
-
   return (target) => {
     const targetName = target.displayName || target.name
     const getIdentifier = (props) => typeof id === 'function' ? id(props) : id

--- a/src/connect/connectWpQuery.js
+++ b/src/connect/connectWpQuery.js
@@ -1,12 +1,18 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import isEqual from 'lodash.isequal'
+import isEqualWith from 'lodash.isequalwith'
 import merge from 'lodash.merge'
 
 import idGen from './idGen'
 import invariants from '../invariants'
 import { createQueryRequest } from '../actions'
 import { makeWpQueryPreloaderFn } from './preloaders'
+
+/**
+ * IDs of queries created through the preloader.
+ * @type {Array<Number>}
+ */
+const queryIds = []
 
 /**
  * Filter `entities` to contain only those whose ID is in `identifiers`.
@@ -32,7 +38,33 @@ function pickEntities (entities, identifiers) {
 }
 
 /**
- * Connect a component to arbitrary data from a WP-API query.
+ * Determine if a value is a primitive. (http://bit.ly/2bf3FYJ)
+ * @param {*} value Value to inspect
+ * @returns {Boolean} Whether value is primitive
+ */
+function isPrimitive (value) {
+  const type = typeof value
+  return value == null || (type !== 'object' && type !== 'function')
+}
+
+/**
+ * Only inspect primitives by default.
+ * Returning `undefined` makes isEqualWith fallback to built-in comparator.
+ * @param {Object} thisProps Current props object
+ * @param {Object} nextProps Next props object
+ * @returns {Boolean}
+ */
+function defaultPropsComparator (thisProps, nextProps) {
+  return isEqualWith(thisProps, nextProps, (value) => {
+    return isPrimitive(value) ? undefined : true
+  })
+}
+
+/**
+ * Connect a component to arbitrary data from a WP-API query. By default
+ * the component will request new data via the given `queryFn` if the
+ * `propsComparatorFn` returns true. The default property comparison
+ * is performed only on primitive values on the props objects.
  *
  * Example, get all posts by an author:
  * ```js
@@ -54,13 +86,20 @@ function pickEntities (entities, identifiers) {
  * })
  * ```
  *
+ * Example, with custom props comparator:
+ * ```js
+ * connectWpQuery((wp) => wp.pages().embed().get(), (thisProps, nextProps) => {
+ *   return thisProps.identifier() !== nextProps.identifier()
+ * })
+ * ```
+ *
  * @params {Function} queryFn Function that returns a wpapi query
- * @returns {Function}
+ * @params {Function} propsComparatorFn Function that determines if new data should be requested by inspecting props
+ * @returns {Function} Decorated component
  */
-export default function connectWpQuery (queryFn) {
+export default function connectWpQuery (queryFn, propsComparatorFn = defaultPropsComparator) {
   invariants.isFunction('queryFn', queryFn)
-
-  const queryIds = []
+  invariants.isFunction('propsComparatorFn', propsComparatorFn)
 
   return (target) => {
     const targetName = target.displayName || target.name
@@ -120,16 +159,13 @@ export default function connectWpQuery (queryFn) {
       }
 
       componentWillReceiveProps (_nextProps) {
-        const thisProps = merge({}, this.props)
-        const nextProps = merge({}, _nextProps)
-
         // Nullify `wordpress` on props objects so that they aren't compared otherwise
         // the addition of a new query object each time will cause infinite dispatches
-        nextProps.wordpress = null
-        thisProps.wordpress = null
+        const thisProps = merge({}, this.props, { wordpress: null })
+        const nextProps = merge({}, _nextProps, { wordpress: null })
 
         // Make a request for new data if the current props and next props are different
-        if (!isEqual(nextProps, thisProps)) {
+        if (!propsComparatorFn(thisProps, nextProps)) {
           this.queryId = queryIds.length ? queryIds.shift() : idGen()
           this.dispatch(nextProps)
         }

--- a/src/sagas.js
+++ b/src/sagas.js
@@ -7,16 +7,15 @@ import { completeRequest, failRequest } from './actions'
 import { Request, RequestTypes } from './constants/ActionTypes'
 
 /**
- * Chain call methods beginning with `fn` that are the keys of `calls` with
- * the value of each being the argument for the corresponding invocation.
- * @param {Function} fn The function to invoke calls on
+ * Chain call methods beginning with `fn`.
+ * @param {Object} obj The object to invoke calls on
  * @param {Object} calls The methods and their args to call
  */
-export function chain (fn, calls) {
-  return Object.keys(calls).reduce((result, method) => {
-    const args = calls[method]
-    return result[method](args)
-  }, fn)
+export function chain (obj, calls) {
+  return calls.reduce((result, call) => {
+    const args = call[1]
+    return args ? result[call[0]](args) : result[call[0]]()
+  }, obj)
 }
 
 /**
@@ -39,16 +38,16 @@ export function chain (fn, calls) {
  * @returns {Function} A function to make a request to the WP-API
  */
 export function derivedQueryFn (contentTypeMethodName, identifier) {
-  return () => chain(WP, {
+  return () => chain(WP, [
     // Call the content type method
-    [contentTypeMethodName]: null,
+    [contentTypeMethodName, null],
     // Call the identifier method
-    [typeof identifier === 'string' ? 'slug' : 'id']: identifier,
+    [typeof identifier === 'string' ? 'slug' : 'id', identifier],
     // Call 'embed' in order that embedded data is in the response
-    embed: null,
+    ['embed'],
     // Call `then` in order to invoke query and return a Promise
-    then: (response) => response
-  })
+    ['then', (response) => response]
+  ])
 }
 
 /**

--- a/test/components/CustomPropsComparator.js
+++ b/test/components/CustomPropsComparator.js
@@ -1,0 +1,26 @@
+/* global jest:false */
+
+jest.disableAutomock()
+
+import React, { Component } from 'react'
+
+import { connectWpQuery } from '../../src/connect'
+
+@connectWpQuery(
+  (wpapi, props) => wpapi.books(props.params.id).get(),
+  (thisProps, nextProps) => thisProps.fn !== nextProps.fn
+)
+export default class Books extends Component {
+  render () {
+    const {
+      query,
+      entities: { books }
+    } = this.props.kasia
+
+    if (!query.complete) {
+      return <div>Loading...</div>
+    }
+
+    return <div>{books[this.props.params.id].slug}</div>
+  }
+}

--- a/test/connect/connectWpQuery.js
+++ b/test/connect/connectWpQuery.js
@@ -4,6 +4,7 @@
 jest.disableAutomock()
 
 jest.mock('../../src/actions')
+jest.mock('../../src/connect/idGen')
 
 import React from 'react'
 import modifyResponse from 'wp-api-response-modify'
@@ -12,12 +13,14 @@ import { mount } from 'enzyme'
 
 import bookJson from '../fixtures/wp-api-responses/book'
 
+import idGen from '../../src/connect/idGen'
 import { createQueryRequest } from '../../src/actions'
 import { Request, RequestTypes } from '../../src/constants/ActionTypes'
 
 import CustomQuery from '../components/CustomQuery'
+import CustomPropsComparator from '../components/CustomPropsComparator'
 
-function setup () {
+function setup (entityId) {
   const mockId = '0'
 
   const dispatch = jest.fn()
@@ -25,23 +28,29 @@ function setup () {
 
   const getState = jest.fn(() => ({
     wordpress: {
-      queries: {},
-      entities: {}
+      queries: {
+        [mockId]: {
+          complete: true,
+          OK: true,
+          entities: [entityId]
+        }
+      },
+      entities: {
+        books: {
+          [String(bookJson.id)]: modifyResponse(bookJson),
+          [String(bookJson.id + 1)]: merge({},
+            modifyResponse(bookJson),
+            { id: bookJson.id + 1, slug: 'new-slug' })
+        }
+      }
     }
   }))
 
-  const store = {
-    dispatch,
-    getState,
-    subscribe
-  }
+  const store = { dispatch, getState, subscribe }
 
-  const props = {
-    store,
-    params: {
-      id: bookJson.id
-    }
-  }
+  const props = { store, params: { id: entityId } }
+
+  idGen.mockReturnValue(mockId)
 
   createQueryRequest.mockImplementation((options) => ({
     id: mockId,
@@ -53,72 +62,71 @@ function setup () {
   return { mockId, store, props }
 }
 
-function mockState (store, props) {
-  props.store = {
-    ...store,
-    getState: () => ({
-      wordpress: {
-        queries: {
-          '1': { // Calling mount() for the 2nd time produces new ID
-            complete: true,
-            OK: true,
-            entities: [bookJson.id]
-          },
-          '2': { // Changed nextProps causes dispatch + new ID
-            complete: true,
-            OK: true,
-            entities: [bookJson.id + 1]
-          }
-        },
-        entities: {
-          books: {
-            [String(bookJson.id)]: modifyResponse(bookJson),
-            [String(bookJson.id + 1)]: merge({}, modifyResponse(bookJson), { slug: 'new-slug' })
-          }
-        }
-      }
-    })
-  }
+function expectRequestCreate (props, mockId, actionIndex = 0) {
+  const dispatch = props.store.dispatch
+  const action = dispatch.mock.calls[actionIndex][0]
+  expect(action.id).toEqual(mockId)
+  expect(action.type).toEqual(Request.Create)
+  expect(action.request).toEqual(RequestTypes.Query)
 }
 
 describe('connectWpQuery', () => {
-  const { mockId, store, props } = setup()
+  describe('with primitive props', () => {
+    const { mockId, props } = setup(bookJson.id)
 
-  let rendered = mount(<CustomQuery {...props} testProp />)
+    const rendered = mount(<CustomQuery {...props} testProp />)
 
-  it('should wrap the component', () => {
-    expect(CustomQuery.__kasia).toBe(true)
-  })
-
-  it('should pass props down', () => {
-    expect(rendered.props().testProp).toBe(true)
-  })
-
-  it('should dispatch REQUEST_CREATE', () => {
-    const dispatch = props.store.dispatch
-    const action = dispatch.mock.calls[0][0]
-    expect(action.id).toEqual(mockId)
-    expect(action.type).toEqual(Request.Create)
-    expect(action.request).toEqual(RequestTypes.Query)
-  })
-
-  it('should render with book slug', () => {
-    mockState(store, props)
-    // TODO why can't I call rendered#update here and avoid new ID + defining explicit state?
-    rendered = mount(<CustomQuery {...props} testProp />)
-    expect(rendered.html()).toEqual('<div>hello</div>')
-  })
-
-  it('should update to new entity with changed props', () => {
-    const nextProps = merge({}, props, {
-      params: {
-        id: String(bookJson.id + 1)
-      }
+    it('should wrap the component', () => {
+      expect(CustomQuery.__kasia).toBe(true)
     })
 
-    rendered.setProps(nextProps)
-    rendered.update()
+    it('should pass props down', () => {
+      expect(rendered.props().testProp).toBe(true)
+    })
 
-    expect(rendered.html()).toEqual('<div>new-slug</div>')
+    it('should dispatch REQUEST_CREATE', () => {
+      expectRequestCreate(props, mockId)
+    })
+
+    it('should render with book slug', () => {
+      expect(rendered.html()).toContain('hello')
+    })
+  })
+
+  describe('with non-primitive props', () => {
+    const { store, mockId, props } = setup(bookJson.id)
+
+    props.fn = () => {}
+
+    const rendered = mount(<CustomQuery {...props} testProp />)
+
+    it('should dispatch REQUEST_CREATE', () => {
+      expectRequestCreate(props, mockId)
+    })
+
+    it('should not dispatch REQUEST_CREATE if function changes on props', () => {
+      props.fn = () => {}
+      rendered.setProps(props)
+      expect(store.dispatch.mock.calls.length).toEqual(1)
+    })
+  })
+
+  describe('with custom props comparator', () => {
+    const { store, mockId, props } = setup(bookJson.id)
+
+    props.fn = () => {}
+
+    const rendered = mount(<CustomPropsComparator {...props} testProp />)
+
+    it('should dispatch REQUEST_CREATE', () => {
+      expectRequestCreate(props, mockId)
+    })
+
+    it('should not dispatch REQUEST_CREATE if function does not change on props', () => {
+      rendered.update()
+      expect(store.dispatch.mock.calls.length).toEqual(1)
+    })
+
+    // TODO test component updates according to the props comparator function (different `props.fn`)
   })
 })

--- a/test/sagas/util.js
+++ b/test/sagas/util.js
@@ -15,10 +15,10 @@ describe('chain', () => {
   }
 
   it('correctly chains method calls', () => {
-    const result = chain(mockApi, {
-      feedOnce: null,
-      feedTwice: 'result'
-    })
+    const result = chain(mockApi, [
+      ['feedOnce'],
+      ['feedTwice', 'result']
+    ])
 
     expect(result).toEqual('result')
   })


### PR DESCRIPTION
- Fix functions passed as props to `connectWpQuery` causing infinite dispatching. ([#16](https://github.com/outlandishideas/kasia/issues/16))
- Added second parameter `propsComparatorFn` to `connectWpQuery`.
- Fix `connectWpPost` derived query chaining failing due to dependency on object property order.
- Updates to README: added docs for new functionality, fix typos ([#19](https://github.com/outlandishideas/kasia/pull/19)).