### PR TITLE
Correctly import default get from lodash.get

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "4"
+  - "6"
 # https://github.com/travis-ci/travis-ci/issues/4653#issuecomment-194051953
 before_install: "if [[ `npm -v` != 4* ]]; then npm i -g npm@4; fi"
 script: "npm run test:coverage"

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Kasia suits applications that are built using these technologies:
 - WordPress
 - [WP-API plugin](http://v2.wp-api.org/)
 - [`node-wpapi`](https://github.com/WP-API/node-wpapi)
+- Node (>= 6)
+
+Please note that in v4.2 the required Node version has been raised to 6.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "is-node-fn": "^1.0.0",
     "lodash.get": "^4.4.2",
     "lodash.merge": "^4.6.0",
-    "normalizr": "^3.2.3",
+    "normalizr": "^2.3.1",
     "pick-to-array": "^1.1.0",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",

--- a/src/connect.js
+++ b/src/connect.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { get } from 'lodash.get'
+import get from 'lodash.get'
 import { connect as reduxConnect } from 'react-redux'
 import { call } from 'redux-saga/effects'
 

--- a/test/universal-journey.js
+++ b/test/universal-journey.js
@@ -29,15 +29,19 @@ const post1 = post
 const post2 = Object.assign({}, post, { id: 17, slug: 'post-2', title: { rendered: 'Post 2' } })
 const post3 = Object.assign({}, post, { id: 18, slug: 'post-3', title: { rendered: 'Post 3' } })
 
-// post to return from queryFn
-let returnPost
 
 // we need to mock responses from WP-API
-jest.mock('../src/util/query-builder', () => ({
-  buildQueryFunction: () => () => new Promise((resolve) => {
+jest.mock('../src/util/query-builder', () => ({ buildQueryFunction: jest.fn() }));
+import { buildQueryFunction } from '../src/util/query-builder'
+
+let returnPost
+
+buildQueryFunction.mockImplementation(() => () =>
+  new Promise((resolve) => {
     setTimeout(() => resolve(returnPost))
   })
-}))
+);
+
 
 function setup (keyEntitiesBy) {
   const { kasiaReducer, kasiaSagas } = kasia({

--- a/test/util/content-types-manager.js
+++ b/test/util/content-types-manager.js
@@ -27,14 +27,15 @@ describe('util/contentTypesManager', () => {
       expect(fn).toThrowError(/Invalid content type object/)
     })
 
-    Object.values(ContentTypes).forEach((builtInType) => {
-      it('throws when name is ' + builtInType, () => {
-        const opts = { name: builtInType, plural: builtInType, slug: builtInType }
+    for (var builtInType in ContentTypes) {
+      const typeName = ContentTypes[builtInType]
+      it('throws when name is ' + typeName, () => {
+        const opts = { name: typeName, plural: typeName, slug: typeName }
         const fn = () => contentTypesManager.register(opts)
-        const expected = `Content type with name "${builtInType}" already exists.`
+        const expected = `Content type with name "${typeName}" already exists.`
         expect(fn).toThrowError(expected)
       })
-    })
+    }
 
     it('adds custom content type to cache', () => {
       const opts = { name: 'article', plural: 'articles', slug: 'articles' }


### PR DESCRIPTION
`lodash.get` exports the get function as its default export. Importing it as though it were an individually exported module (rather than the default) doesn't work–it results in an undefined function error.