### PR TITLE
Consolidate counter rewind

### DIFF
--- a/src/connect.js
+++ b/src/connect.js
@@ -100,9 +100,8 @@ const base = (target) => {
     componentWillMount () {
       const state = this.props.wordpress
       const numQueries = Object.keys(state.queries).length
-      const nextCounterIndex = queryCounter.observeNext()
 
-      if (!numQueries && nextCounterIndex > 0 && !haveWarned[WARN_NO_REWIND]) {
+      if (!numQueries && queryCounter.value > 0 && !haveWarned[WARN_NO_REWIND]) {
         console.log(
           '[kasia] the query counter and queries in the store are not in sync. ' +
           'This may be because you are not calling `kasia.rewind()` before running preloaders.'

--- a/src/connect.js
+++ b/src/connect.js
@@ -15,16 +15,8 @@ import { fetch } from './redux/sagas'
 const WARN_NO_ENTITIES_PROP = 0
 const WARN_NO_REWIND = 1
 
-// Is a component the first Kasia component to mount?
-let firstMount = true
-
 // What have we warned the consumer of?
 let haveWarned = []
-
-/** Reset first mount flag, should be called before SSR of each request. */
-export function rewind () {
-  firstMount = true
-}
 
 /** Get entity identifier: either `id` as-is or the result of calling `id(props)`. */
 export function identifier (displayName, id, props) {
@@ -116,13 +108,6 @@ const base = (target) => {
           'This may be because you are not calling `kasia.rewind()` before running preloaders.'
         )
         haveWarned[WARN_NO_REWIND] = true
-      }
-
-      // When doing SSR we need to reset the counter so that components start
-      // at queryId=0, aligned with the preloaders that have been run for them.
-      if (firstMount) {
-        queryCounter.reset()
-        firstMount = false
       }
 
       const queryId = this.queryId = queryCounter.next()

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,6 @@ import queryCounter from './util/query-counter'
 import { default as _runSagas } from './util/run-sagas'
 import { setWP } from './wpapi'
 import { watchRequests } from './redux/sagas'
-import { rewind as connectRewind } from './connect'
 import { createQueryRequest, createPostRequest } from './redux/actions'
 
 export * from './util/preload'
@@ -24,13 +23,12 @@ const COMPONENTS_BASE = {
 /** Reset the internal query counter and first mount bool.
  *  Should be called before each SSR. */
 kasia.rewind = function rewind () {
-  connectRewind()
   queryCounter.reset()
 }
 
 /** Run all `sagas` until they are complete. */
 export function runSagas (store, sagas) {
-  kasia.rewind()
+  queryCounter.reset()
   return _runSagas(store, sagas)
 }
 

--- a/src/util/query-counter.js
+++ b/src/util/query-counter.js
@@ -1,7 +1,7 @@
 let queryId = 0
 
 export default {
-  observeNext () {
+  get value () {
     return queryId
   },
   reset () {


### PR DESCRIPTION
Moves all counter resets into the index file, where the rewind function lives, making the `firstMount` flag redundant.